### PR TITLE
Use min-height on .pages_background instead of height

### DIFF
--- a/src/components/Pages.vue
+++ b/src/components/Pages.vue
@@ -47,7 +47,7 @@ export default {
   border-color: black;
   border-style: solid;
   border-width: 1px;
-  height: 94vh;
+  min-height: 94vh;
   padding: 10px;
 }
 


### PR DESCRIPTION
This will ensure that if the content is larger than the screen, the user can scroll to reach the button, but will at least be able to see all information on the page.